### PR TITLE
Fix time stamp format

### DIFF
--- a/org-drill.el
+++ b/org-drill.el
@@ -722,7 +722,6 @@ CMD is bound, or nil if it is not bound to a key."
    (concat "[" (cdr org-time-stamp-formats) "]")
    time))
 
-
 (defun org-drill-map-entries (func &optional scope drill-match &rest skip)
   "Like `org-map-entries', but only drill entries are processed."
   (let ((org-drill-match (or drill-match org-drill-match)))
@@ -3075,12 +3074,13 @@ all drill items are considered to be due for review, unless they
 have been reviewed within the last `org-drill-cram-hours'
 hours."
   (interactive)
-  (setq (oref session cram-mode) t)
+  (when (and (boundp 'session) (object-of-class-p session 'org-drill-session-class))
+    (oset session cram-mode t)
+  (setq (oref session cram-mode) t))
   (org-drill scope drill-match))
 
 (defun org-drill-cram-tree ()
   "Run  an interactive drill session in 'cram mode' using subtree at point.
-
 See also, `org-drill-cram' and `org-drill-tree'."
   (interactive)
   (org-drill-cram 'tree))

--- a/org-drill.el
+++ b/org-drill.el
@@ -719,7 +719,7 @@ CMD is bound, or nil if it is not bound to a key."
 (defun org-drill-time-to-inactive-org-timestamp (time)
   "Convert TIME into org-mode timestamp."
   (format-time-string
-   (concat "[" (substring (cdr org-time-stamp-formats) 1 -1) "]")
+   (concat "[" (substring org-time-stamp-formats) "]")
    time))
 
 (defun org-drill-map-entries (func &optional scope drill-match &rest skip)

--- a/org-drill.el
+++ b/org-drill.el
@@ -719,8 +719,9 @@ CMD is bound, or nil if it is not bound to a key."
 (defun org-drill-time-to-inactive-org-timestamp (time)
   "Convert TIME into org-mode timestamp."
   (format-time-string
-   (concat "[" (cdr substring org-time-stamp-formats) "]")
+   (concat "[" (cdr org-time-stamp-formats) "]")
    time))
+
 
 (defun org-drill-map-entries (func &optional scope drill-match &rest skip)
   "Like `org-map-entries', but only drill entries are processed."

--- a/org-drill.el
+++ b/org-drill.el
@@ -719,7 +719,7 @@ CMD is bound, or nil if it is not bound to a key."
 (defun org-drill-time-to-inactive-org-timestamp (time)
   "Convert TIME into org-mode timestamp."
   (format-time-string
-   (concat "[" (substring org-time-stamp-formats) "]")
+   (concat "[" (cdr substring org-time-stamp-formats) "]")
    time))
 
 (defun org-drill-map-entries (func &optional scope drill-match &rest skip)


### PR DESCRIPTION
Originally the line `(substring (cdr org-time-stamp-formats) 1 -1)` removed the first and the last character from the 
time stamp string, which resulted in the output `:DRILL_LAST_REVIEWED: [Y-08-25 sun 14:%]`. This time stamp was not readable on the second run of org-drill. With this fix the org-drill produces timestamp:
`:DRILL_LAST_REVIEWED: [2024-08-25 sun 14:38]`